### PR TITLE
feat: set `main.Version` on `make build`

### DIFF
--- a/.github/workflows/test-coverage-badge.yaml
+++ b/.github/workflows/test-coverage-badge.yaml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
   pull-requests: write 
 
 concurrency:
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.head_ref }}
+        fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
 
     - name: Set up Go
       uses: actions/setup-go@v5
@@ -52,5 +55,6 @@ jobs:
       if: steps.verify-changed-files.outputs.files_changed == 'true'
       uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ github.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         branch: ${{ github.head_ref }}
+        force_with_lease: true

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+VERSION=$(shell git describe --tags --always)
+
 build:
-	go build -o bin/meu-pau-no-seu-bot cmd/meu_pau_no_seu_bot/main.go
+	mkdir -p bin/ && go build -ldflags "-X main.Version=$(VERSION)" -o ./bin/ ./...	
 
 clean:
 	rm -f bin/meu-pau-no-seu-bot

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # meu-pau-no-seu-bot
+![Coverage](https://img.shields.io/badge/Coverage-0.0%25-red)
 


### PR DESCRIPTION
# What it does
- populate a variable `VERSION` with the current git version when running the `Makefile`
- set the `main.Version` with the current git version on build

## Closes
- [x] https://github.com/igmagollo/meu-pau-no-seu-bot/issues/5