### PR TITLE
ci/cd: add test and coverage actions

### DIFF
--- a/.github/workflows/test-coverage-badge.yaml
+++ b/.github/workflows/test-coverage-badge.yaml
@@ -1,0 +1,48 @@
+name: Test Coverage Badge
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Run Test
+      run: |
+        go test -v ./... -coverprofile=coverage.out
+        go tool cover -func=coverage.out -o=coverage.out
+
+    - name: Generate Coverage Badge
+      uses: tj-actions/coverage-badge-go@v2
+      with:
+        filename: coverage.out
+
+    - name: Verify Changed files
+      uses: tj-actions/verify-changed-files@v20
+      id: verify-changed-files
+      with:
+        files: README.md
+
+    - name: Commit changes
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add README.md
+        git commit -m "chore: updated coverage badge"
+
+    - name: Push changes
+      if: steps.verify-changed-files.outputs.files_changed == 'true'
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ github.token }}
+        branch: ${{ github.head_ref }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+
+    - name: Run Test
+      run: |
+        go test -v ./...


### PR DESCRIPTION
# What it does
- add test action on pull request
  - uses `setup-go` to setup and cache golang module and build
- add test coverage updating the badge on push main
  - uses `setup-go` to setup and cache golang module and build
  - generates the coverage badge and pushes it to the main

# Closes
- [x] https://github.com/igmagollo/meu-pau-no-seu-bot/issues/4