### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-cache.yaml
+++ b/.github/workflows/test-cache.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/igmagollo/meu-pau-no-seu-bot/security/code-scanning/1](https://github.com/igmagollo/meu-pau-no-seu-bot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only needs to read the repository contents (e.g., to check out the code and run tests), we will set `contents: read` as the minimal required permission. This change ensures that the `GITHUB_TOKEN` has the least privilege necessary to execute the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
